### PR TITLE
Add pycharm config to test __init__.py

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+if "rye" not in os.environ["PATH"]:
+    os.environ["PATH"] += f":{os.path.expanduser('~')}/.rye/shims"


### PR DESCRIPTION
On PyCharm, the IDE does not find the correct path to the binary. So we add a standard rye shim to the path when initializing the tests. This should automatically be skipped on any github runner, since rye is available since we run from shell
