### PR TITLE
Verbose packaging option

### DIFF
--- a/src/box/cli.py
+++ b/src/box/cli.py
@@ -27,9 +27,16 @@ def init(quiet):
 
 
 @cli.command(name="package")
-def package():
+@click.option(
+    "-v",
+    "--verbose",
+    default=False,
+    is_flag=True,
+    help="Flag to enable verbose mode.",
+)
+def package(verbose):
     """Build the project, then package it with PyApp."""
-    my_packager = PackageApp()
+    my_packager = PackageApp(verbose=verbose)
     my_packager.build()
     my_packager.package()
     click.echo(

--- a/src/box/packager.py
+++ b/src/box/packager.py
@@ -19,8 +19,12 @@ PYAPP_SOURCE = "https://github.com/ofek/pyapp/releases/latest/download/source.ta
 class PackageApp:
     """Package the project with PyApp."""
 
-    def __init__(self):
-        """Initialize the PackageApp class."""
+    def __init__(self, verbose=False):
+        """Initialize the PackageApp class.
+
+        :param verbose: bool, flag to enable verbose mode.
+        """
+        self._verbose = verbose
         # self._builder = box_config.builder
         self._dist_path = None
         self._pyapp_path = None
@@ -54,7 +58,10 @@ class PackageApp:
 
     def _build_rye(self):
         """Build the project with rye."""
-        subprocess.run(["rye", "build"], stdout=subprocess.DEVNULL)
+        if self._verbose:
+            subprocess.run(["rye", "build"])
+        else:
+            subprocess.run(["rye", "build"], stdout=subprocess.DEVNULL)
 
         self._dist_path = Path.cwd().joinpath("dist")
 
@@ -123,12 +130,17 @@ class PackageApp:
         Environment must already be setup and PyApp source code must already be
         extracted in `self._pyapp_path`.
         """
-        subprocess.run(
-            ["cargo", "build", "--release"],
-            cwd=self._pyapp_path,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        if self._verbose:
+            subprocess.run(
+                ["cargo", "build", "--release"], cwd=self._pyapp_path
+            )
+        else:
+            subprocess.run(
+                ["cargo", "build", "--release"],
+                cwd=self._pyapp_path,
+                stdout=subprocess.DEVNULL,
+                # stderr=subprocess.DEVNULL,
+            )
 
         # create release folder if it does not exist
         self._release_dir.mkdir(exist_ok=True, parents=True)
@@ -145,10 +157,6 @@ class PackageApp:
         for var in list(os.environ):
             if var.startswith("PYAPP"):
                 del os.environ[var]
-
-        print("set env")
-        print(self._dist_path)
-        print(os.listdir(self._dist_path))
 
         # find the tar.gz file in dist folder with correct version number
         dist_file = None

--- a/src/box/packager.py
+++ b/src/box/packager.py
@@ -24,7 +24,10 @@ class PackageApp:
 
         :param verbose: bool, flag to enable verbose mode.
         """
-        self._verbose = verbose
+        self.subp_kwargs = {}
+        if not verbose:
+            self.subp_kwargs["stdout"] = subprocess.DEVNULL
+
         # self._builder = box_config.builder
         self._dist_path = None
         self._pyapp_path = None
@@ -58,10 +61,7 @@ class PackageApp:
 
     def _build_rye(self):
         """Build the project with rye."""
-        if self._verbose:
-            subprocess.run(["rye", "build"])
-        else:
-            subprocess.run(["rye", "build"], stdout=subprocess.DEVNULL)
+        subprocess.run(["rye", "build"], **self.subp_kwargs)
 
         self._dist_path = Path.cwd().joinpath("dist")
 
@@ -130,17 +130,9 @@ class PackageApp:
         Environment must already be setup and PyApp source code must already be
         extracted in `self._pyapp_path`.
         """
-        if self._verbose:
-            subprocess.run(
-                ["cargo", "build", "--release"], cwd=self._pyapp_path
-            )
-        else:
-            subprocess.run(
-                ["cargo", "build", "--release"],
-                cwd=self._pyapp_path,
-                stdout=subprocess.DEVNULL,
-                # stderr=subprocess.DEVNULL,
-            )
+        subprocess.run(
+            ["cargo", "build", "--release"], cwd=self._pyapp_path, **self.subp_kwargs
+        )
 
         # create release folder if it does not exist
         self._release_dir.mkdir(exist_ok=True, parents=True)

--- a/tests/cli/test_cli_packager.py
+++ b/tests/cli/test_cli_packager.py
@@ -7,6 +7,7 @@ import pytest
 
 from box.cli import cli
 
+
 @pytest.mark.parametrize("verbose", [True, False])
 def test_package_project(rye_project, mocker, verbose):
     """Package an initialized project, verbose and not."""
@@ -52,7 +53,5 @@ def test_package_project(rye_project, mocker, verbose):
     # assert system calls
     sp_run_mock.assert_any_call(["rye", "build"], **subp_kwargs)
     sp_run_mock.assert_called_with(
-        ["cargo", "build", "--release"],
-        cwd=pyapp_dir,
-        **subp_kwargs
+        ["cargo", "build", "--release"], cwd=pyapp_dir, **subp_kwargs
     )

--- a/tests/cli/test_cli_packager.py
+++ b/tests/cli/test_cli_packager.py
@@ -3,15 +3,24 @@
 import urllib.request
 
 from click.testing import CliRunner
+import pytest
 
 from box.cli import cli
 
-
-def test_package_project(rye_project, mocker):
-    """Package an initialized project."""
+@pytest.mark.parametrize("verbose", [True, False])
+def test_package_project(rye_project, mocker, verbose):
+    """Package an initialized project, verbose and not."""
     # mock subprocess
     sp_devnull_mock = mocker.patch("subprocess.DEVNULL")
     sp_run_mock = mocker.patch("subprocess.run")
+
+    # handle verbose mode
+    if verbose:
+        cmd = ["package", "-v"]
+        subp_kwargs = {}
+    else:
+        cmd = ["package"]
+        subp_kwargs = {"stdout": sp_devnull_mock}
 
     # mock urllib.request.urlretrieve
     mocker.patch.object(urllib.request, "urlretrieve")
@@ -36,14 +45,14 @@ def test_package_project(rye_project, mocker):
     cargo_target.joinpath("pyapp").touch()
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["package"])
+    result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
     assert result.output.__contains__("Project successfully packaged.")
 
-    sp_run_mock.assert_any_call(["rye", "build"], stdout=sp_devnull_mock)
+    # assert system calls
+    sp_run_mock.assert_any_call(["rye", "build"], **subp_kwargs)
     sp_run_mock.assert_called_with(
         ["cargo", "build", "--release"],
         cwd=pyapp_dir,
-        stdout=sp_devnull_mock,
-        stderr=sp_devnull_mock,
+        **subp_kwargs
     )

--- a/tests/func/test_packager.py
+++ b/tests/func/test_packager.py
@@ -198,7 +198,6 @@ def test_package_pyapp_cargo_and_move(rye_project, mocker):
         ["cargo", "build", "--release"],
         cwd=pyapp_path,
         stdout=sp_devnull_mock,
-        stderr=sp_devnull_mock,
     )
     exp_binary = rye_project.joinpath(f"target/release/{rye_project.name}")
     assert exp_binary.is_file()


### PR DESCRIPTION
Add a flag to the packager to run in verbose mode with `-v`. If activated, this will prompt the `stdout` to the terminal from the rye build and the cargo release build. Errors are always displayed.

