### PR TITLE
fix initialization when quiet and no script entry

### DIFF
--- a/src/box/initialization.py
+++ b/src/box/initialization.py
@@ -74,8 +74,8 @@ class InitializeProject:
 
         if self._quiet:  # all automatic
             if options == []:  # choose package_name:run and raise warning
-                app_entry = f"{self.pyproj.name_pkg}:run"
-                click.echo(f"Warning: No app entry found, using {app_entry}:run.")
+                self.app_entry = f"{self.pyproj.name_pkg}:run"
+                click.echo(f"Warning: No app entry found, using {self.app_entry}:run.")
             else:
                 self.app_entry = options[0]
         else:

--- a/tests/cli/test_cli_initialization.py
+++ b/tests/cli/test_cli_initialization.py
@@ -28,7 +28,31 @@ def test_initialize_project_app_entry_typed(rye_project_no_box, app_entry):
 
 
 def test_initialize_project_quiet(rye_project_no_box):
-    """Initialize a new project."""
+    """Initialize a new project quietly."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "-q"])
+    assert result.exit_code == 0
+    assert "Project initialized." not in result.output
+
+    # assert it's now a box project
+    pyproj = PyProjectParser()
+    assert pyproj.is_box_project
+
+
+def test_initialize_project_quiet_no_project_script(rye_project_no_box):
+    """Initialize a new project quietly with app_entry as the package name."""
+    with open("pyproject.toml", "r") as f:
+        toml_data = f.read().split("\n")
+    # delete the line with scripts and save back out
+    for it, line in enumerate(toml_data):
+        if "project.scripts" in line:
+            idx = it
+            break
+    toml_data.pop(idx)
+    toml_data.pop(idx + 1)
+    with open("pyproject.toml", "w") as f:
+        f.write("\n".join(toml_data))
+
     runner = CliRunner()
     result = runner.invoke(cli, ["init", "-q"])
     assert result.exit_code == 0


### PR DESCRIPTION
A code error prevented initializing quietly without any scripts listed. This is now tested and fixed.
