### PR TITLE
Fix cleaner issue, nice formatting

### DIFF
--- a/src/box/formatters.py
+++ b/src/box/formatters.py
@@ -6,25 +6,28 @@ These methods are used to standardize the output of the CLI commands.
 import rich_click as click
 
 
-def info(msg: str) -> None:
+def info(msg: str, **kwargs) -> None:
     """Echo an info message to the console.
 
     :param msg: Info message to print
+    :param kwargs: Additional keyword arguments for click.secho
     """
-    click.secho(f"Info: {msg}", fg="blue")
+    click.secho(f"Info: {msg}", fg="cyan", **kwargs)
 
 
-def success(msg: str) -> None:
+def success(msg: str, **kwargs) -> None:
     """Echo a success message to the console.
 
     :param msg: Success message to print
+    :param kwargs: Additional keyword arguments for click.secho
     """
-    click.secho(f"Success: {msg}", fg="green")
+    click.secho(f"Success: {msg}", fg="green", **kwargs)
 
 
-def warning(msg: str) -> None:
+def warning(msg: str, **kwargs) -> None:
     """Echo a warning message to the console.
 
     :param msg: Warning message to print
+    :param kwargs: Additional keyword arguments for click.secho
     """
-    click.secho(f"Warning: {msg}", fg="yellow")
+    click.secho(f"Warning: {msg}", fg="yellow", **kwargs)


### PR DESCRIPTION
- Running `box clean -p` now checks if `build` folder actually exists. 
This resulted in an error before.
- Nice colorful string formatting
