### PR TITLE
Pipe stderr into DEVNULL

### DIFF
--- a/src/box/packager.py
+++ b/src/box/packager.py
@@ -28,6 +28,7 @@ class PackageApp:
         self.subp_kwargs = {}
         if not verbose:
             self.subp_kwargs["stdout"] = subprocess.DEVNULL
+            self.subp_kwargs["stderr"] = subprocess.DEVNULL
 
         # self._builder = box_config.builder
         self._dist_path = None
@@ -59,7 +60,6 @@ class PackageApp:
         self._get_pyapp()
         self._set_env()
         self._package_pyapp()
-        fmt.success("Project packaged with PyApp.")
 
     def _build_rye(self):
         """Build the project with rye."""

--- a/tests/cli/test_cli_packager.py
+++ b/tests/cli/test_cli_packager.py
@@ -16,12 +16,13 @@ def test_package_project(rye_project, mocker, verbose):
     sp_run_mock = mocker.patch("subprocess.run")
 
     # handle verbose mode
+    subp_kwargs = {}
     if verbose:
         cmd = ["package", "-v"]
-        subp_kwargs = {}
     else:
         cmd = ["package"]
-        subp_kwargs = {"stdout": sp_devnull_mock}
+        subp_kwargs["stdout"] = sp_devnull_mock
+        subp_kwargs["stderr"] = sp_devnull_mock
 
     # mock urllib.request.urlretrieve
     mocker.patch.object(urllib.request, "urlretrieve")

--- a/tests/func/test_packager.py
+++ b/tests/func/test_packager.py
@@ -56,7 +56,7 @@ def test_build_rye(rye_project, mocker):
     packager = PackageApp()
     packager.build()
 
-    sp_mock.assert_called_with(["rye", "build"], stdout=mocker.ANY)
+    sp_mock.assert_called_with(["rye", "build"], stdout=mocker.ANY, stderr=mocker.ANY)
 
     expected_path = rye_project.joinpath("dist")
     assert packager._dist_path == expected_path
@@ -198,6 +198,7 @@ def test_package_pyapp_cargo_and_move(rye_project, mocker):
         ["cargo", "build", "--release"],
         cwd=pyapp_path,
         stdout=sp_devnull_mock,
+        stderr=sp_devnull_mock,
     )
     exp_binary = rye_project.joinpath(f"target/release/{rye_project.name}")
     assert exp_binary.is_file()


### PR DESCRIPTION
Cargo prints status to stderr. In non-verbose mode, pipe all the statuses into DEVNULL in order to not overclutter the temrinal.
