### PR TITLE
Fix issues for windows and add tests

### DIFF
--- a/src/box/cli.py
+++ b/src/box/cli.py
@@ -42,9 +42,10 @@ def package(verbose):
     my_packager = PackageApp(verbose=verbose)
     my_packager.build()
     my_packager.package()
+    binary_file = my_packager.binary_name
     fmt.success(
-        "Project successfully packaged. "
-        "You can find the binary file in the `target/release` folder."
+        f"Project successfully packaged.\n"
+        f"You can find the executable file {binary_file.name} in the `target/release` folder."
     )
 
 

--- a/src/box/config.py
+++ b/src/box/config.py
@@ -103,5 +103,5 @@ def pyproject_writer(key: str, value: Any) -> None:
 
     box_table.update({key: value})
 
-    with open(pyproject_file, "w") as f:
+    with open(pyproject_file, "w", newline="\n") as f:
         tomlkit.dump(doc, f)

--- a/src/box/packager.py
+++ b/src/box/packager.py
@@ -30,6 +30,8 @@ class PackageApp:
             self.subp_kwargs["stdout"] = subprocess.DEVNULL
             self.subp_kwargs["stderr"] = subprocess.DEVNULL
 
+        self.binary_name = None  # name of the binary file at the end of packaging
+
         # self._builder = box_config.builder
         self._dist_path = None
         self._pyapp_path = None
@@ -140,10 +142,15 @@ class PackageApp:
         self._release_dir.mkdir(exist_ok=True, parents=True)
 
         # move package to dev folder and rename it to module_name
-        shutil.move(
-            self._pyapp_path.joinpath("target/release/pyapp"),
-            self._release_dir.joinpath(self._config.name_pkg),
-        )
+        binary_path = self._pyapp_path.joinpath("target/release/pyapp")
+        suffix = ""
+        if not binary_path.is_file():
+            binary_path = binary_path.with_suffix(".exe")  # we are probably on windows!
+            suffix = ".exe"
+        self.binary_name = self._release_dir.joinpath(
+            self._config.name_pkg
+        ).with_suffix(suffix)
+        shutil.move(binary_path, self.binary_name)
 
     def _set_env(self):
         """Set the environment for packaging the project with PyApp."""

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -1,5 +1,6 @@
 # Test the pyproject parser
 
+from pathlib import Path
 
 import pytest
 
@@ -97,3 +98,17 @@ def test_pyproject_writer_change_builder(tmp_path_chdir):
     pyproject_writer("builder", "hatch")
     parser = PyProjectParser()
     assert parser.builder == "hatch"
+
+
+def test_pyproject_writer_called_with_newline(tmp_path_chdir, mocker):
+    """Ensure newline is always '\n', even on Windows (otherwise issue with tomllib)."""
+    fname = "pyproject.toml"
+    tmp_path_chdir.joinpath(fname).write_text(TOML_BASIC_FILE)
+
+    # mock open
+    mock_open = mocker.patch("builtins.open", mocker.mock_open())
+
+    pyproject_writer("builder", "rye")
+    print(tmp_path_chdir.absolute())
+
+    mock_open.assert_called_with(Path(fname), "w", newline="\n")

--- a/tests/func/test_packager.py
+++ b/tests/func/test_packager.py
@@ -177,13 +177,14 @@ def test_get_pyapp_wrong_no_pyapp_folder(rye_project, mocker):
     assert e.value.args[0].__contains__("Error: no pyapp source code folder found.")
 
 
-def test_package_pyapp_cargo_and_move(rye_project, mocker):
+@pytest.mark.parametrize("binary_extensions", [".exe", ""])
+def test_package_pyapp_cargo_and_move(rye_project, mocker, binary_extensions):
     """Ensure cargo is called correctly and final binary moved to the right folder."""
     pyapp_path = rye_project.joinpath("build/pyapp-vx.y.z")
     cargo_binary_folder = pyapp_path.joinpath("target/release")
     cargo_binary_folder.mkdir(parents=True)
 
-    pyapp_binary = cargo_binary_folder.joinpath("pyapp")
+    pyapp_binary = cargo_binary_folder.joinpath("pyapp").with_suffix(binary_extensions)
     pyapp_binary.write_text("not really a binary")
 
     # mock subprocess.run
@@ -200,7 +201,9 @@ def test_package_pyapp_cargo_and_move(rye_project, mocker):
         stdout=sp_devnull_mock,
         stderr=sp_devnull_mock,
     )
-    exp_binary = rye_project.joinpath(f"target/release/{rye_project.name}")
+    exp_binary = rye_project.joinpath(
+        f"target/release/{rye_project.name}{binary_extensions}"
+    )
     assert exp_binary.is_file()
     assert exp_binary.read_text() == "not really a binary"
 

--- a/tests/unit/test_qtcowsay.py
+++ b/tests/unit/test_qtcowsay.py
@@ -1,5 +1,6 @@
 # Build the `qtcowsay` project with PyApp.
 
+import os
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -19,6 +20,8 @@ def test_gui_build():
     with runner.isolated_filesystem():
         # app expected
         app_expected = Path("target/release/qtcowsay")
+        if os.name == "nt":  # on windows with have an .exe!
+            app_expected = app_expected.with_suffix(".exe")
 
         # clone the repo
         Repo.clone_from(GIT_URL, ".")


### PR DESCRIPTION
Ad windows fixes and check that all tests run on windows.
- executable on windows has an `.exe` suffix. this is now properly handled
- `tomllib` had issues when file was not opened with a specified line ending. specify the line ending and fixing it to `\n`.