### PR TITLE
Allow for extra/optional depencendy installation when packaging

### DIFF
--- a/src/box/config.py
+++ b/src/box/config.py
@@ -1,7 +1,7 @@
 # Parse the pyproject.toml file
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import tomlkit
 
@@ -47,6 +47,14 @@ class PyProjectParser:
     def name_pkg(self) -> str:
         """Return the name of the package (project name with '-' replaced by '_')."""
         return self.name.replace("-", "_")
+
+    @property
+    def optional_dependencies(self) -> Union[str, None]:
+        """Return optional dependencies for the project, or `None` if no key found."""
+        try:
+            return self._pyproject["tool"]["box"]["optional_deps"]
+        except KeyError:
+            return None
 
     @property
     def possible_app_entries(self) -> Dict:

--- a/src/box/initialization.py
+++ b/src/box/initialization.py
@@ -12,7 +12,6 @@ class InitializeProject:
     """Initialize a new project.
 
     # todo: allow for custom build command, custom dist folder
-    # todo: prompts for: builder, dist folder, app entry when running `box init`
     """
 
     def __init__(self, quiet: bool = False):
@@ -33,6 +32,7 @@ class InitializeProject:
         :param app_entry: the app entry point
         """
         self._set_builder()
+        self._set_optional_deps()
         self._set_app_entry()
 
         if not self._quiet:
@@ -95,6 +95,19 @@ class InitializeProject:
                 query_app_entry(query_text, options)
 
         pyproject_writer("app_entry", self.app_entry)
+
+    def _set_optional_deps(self):
+        """Set optional dependencies for the project (if any)."""
+        if self._quiet:
+            opt_deps = ""
+        else:
+            opt_deps = click.prompt(
+                "Provide any optional dependencies for the project.",
+                type=str,
+                default="",
+            )
+        if opt_deps != "":
+            pyproject_writer("optional_deps", opt_deps)
 
     def _set_pyproj(self):
         """Check if the pyproject.toml file is valid."""

--- a/src/box/packager.py
+++ b/src/box/packager.py
@@ -172,6 +172,8 @@ class PackageApp:
         os.environ["PYAPP_PROJECT_PATH"] = str(dist_file)
         # fixme: this whole thing is a hack. give options for entry, see PyApp docs
         os.environ["PYAPP_EXEC_SPEC"] = self._config.app_entry
+        if value := self._config.optional_dependencies:
+            os.environ["PYAPP_PIP_OPTIONAL_DEPS"] = value
 
     # STATIC METHODS #
     @staticmethod

--- a/tests/cli/test_cli_initialization.py
+++ b/tests/cli/test_cli_initialization.py
@@ -7,7 +7,7 @@ from box.cli import cli
 from box.config import PyProjectParser
 
 
-@pytest.mark.parametrize("app_entry", ["hello", "127\nhello"])
+@pytest.mark.parametrize("app_entry", ["\nhello", "gui\n127\nhello"])
 def test_initialize_project_app_entry_typed(rye_project_no_box, app_entry):
     """Initialize a new project."""
     runner = CliRunner()
@@ -24,7 +24,10 @@ def test_initialize_project_app_entry_typed(rye_project_no_box, app_entry):
     pyproj = PyProjectParser()
     app_entry_exp = app_entry.split("\n")[-1]
     assert pyproj.app_entry == app_entry_exp
-    # todo: assert name is in pyproject.toml under [tool.box]
+
+    # assert that extra dependencies were set
+    if (deps_exp := app_entry.split("\n")[0]) != "":
+        assert pyproj.optional_dependencies == deps_exp
 
 
 def test_initialize_project_quiet(rye_project_no_box):
@@ -41,7 +44,7 @@ def test_initialize_project_quiet(rye_project_no_box):
 
 def test_initialize_project_quiet_no_project_script(rye_project_no_box):
     """Initialize a new project quietly with app_entry as the package name."""
-    with open("pyproject.toml", "r") as f:
+    with open("pyproject.toml") as f:
         toml_data = f.read().split("\n")
     # delete the line with scripts and save back out
     for it, line in enumerate(toml_data):

--- a/tests/cli/test_cli_initialization.py
+++ b/tests/cli/test_cli_initialization.py
@@ -10,6 +10,15 @@ from box.config import PyProjectParser
 @pytest.mark.parametrize("app_entry", ["\nhello", "gui\n127\nhello"])
 def test_initialize_project_app_entry_typed(rye_project_no_box, app_entry):
     """Initialize a new project."""
+    # modify pyproject.toml to contain an app entry
+    with open("pyproject.toml") as fin:
+        toml_data = fin.read().split("\n")
+    idx = toml_data.index("[build-system]")
+    toml_data.insert(idx, "[project.scripts]")
+    toml_data.insert(idx + 1, "run = 'something'\n")
+    with open("pyproject.toml", "w") as fout:
+        fout.write("\n".join(toml_data))
+
     runner = CliRunner()
     result = runner.invoke(cli, ["init"], input=app_entry)
 
@@ -44,18 +53,6 @@ def test_initialize_project_quiet(rye_project_no_box):
 
 def test_initialize_project_quiet_no_project_script(rye_project_no_box):
     """Initialize a new project quietly with app_entry as the package name."""
-    with open("pyproject.toml") as f:
-        toml_data = f.read().split("\n")
-    # delete the line with scripts and save back out
-    for it, line in enumerate(toml_data):
-        if "project.scripts" in line:
-            idx = it
-            break
-    toml_data.pop(idx)
-    toml_data.pop(idx + 1)
-    with open("pyproject.toml", "w") as f:
-        f.write("\n".join(toml_data))
-
     runner = CliRunner()
     result = runner.invoke(cli, ["init", "-q"])
     assert result.exit_code == 0

--- a/tests/func/test_initialization.py
+++ b/tests/func/test_initialization.py
@@ -14,7 +14,7 @@ def test_app_entry(rye_project):
     init.initialize()
 
     pyproj = PyProjectParser()
-    assert pyproj.app_entry == f"{rye_project.name}:hello"
+    assert pyproj.app_entry == f"{rye_project.name}:run"
 
 
 def test_set_builder(rye_project):


### PR DESCRIPTION
This won't work yet, will require `pyapp>0.14.0`
