### PR TITLE
add project checks to all modules

### DIFF
--- a/src/box/cleaner.py
+++ b/src/box/cleaner.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import shutil
 
-from box.config import PyProjectParser
 import box.formatters as fmt
 
 
@@ -57,23 +56,8 @@ class CleanProject:
             if target:
                 self.folders_to_clean.append("target")
 
-    @property
-    def _check_box_project(self) -> bool:
-        """Check if we are in a box folder, otherwise quit.
-
-        :return: Bool stating if the project is a box folder.
-        """
-        try:
-            return PyProjectParser().is_box_project
-        except FileNotFoundError:
-            return False
-
     def clean(self):
         """Clean the project according to the options selected."""
-        # check if in project folder, if not exit
-        if not self._check_box_project:
-            fmt.warning("Not a box project. Cleaning canceled.")
-            return
         # delete all folders_to_clean and files therein
         self._clean_folders()
         self._clean_build_folder()

--- a/src/box/cli.py
+++ b/src/box/cli.py
@@ -4,6 +4,7 @@ from box.cleaner import CleanProject
 from box.initialization import InitializeProject
 import box.formatters as fmt
 from box.packager import PackageApp
+import box.utils as ut
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -25,6 +26,7 @@ def cli():
 )
 def init(quiet):
     """Initialize a new project in the current folder."""
+    ut.check_pyproject()
     my_init = InitializeProject(quiet=quiet)
     my_init.initialize()
 
@@ -39,6 +41,7 @@ def init(quiet):
 )
 def package(verbose):
     """Build the project, then package it with PyApp."""
+    ut.check_boxproject()
     my_packager = PackageApp(verbose=verbose)
     my_packager.build()
     my_packager.package()
@@ -95,6 +98,7 @@ def clean(dist, build, target, source_pyapp, pyapp_folder):
     By default, the `dist`, `build`, and `target` folders are deleted.
     The cleaner will ensure that you are in an initialized `box` project folder.
     """
+    ut.check_boxproject()
     my_cleaner = CleanProject(
         dist=dist,
         build=build,

--- a/src/box/utils.py
+++ b/src/box/utils.py
@@ -4,6 +4,24 @@ from contextlib import contextmanager
 import os
 from pathlib import Path
 
+from rich_click import ClickException
+
+from box.config import PyProjectParser
+
+
+def check_boxproject() -> None:
+    """Check if the box project is already initialized."""
+    check_pyproject()
+    pyproj = PyProjectParser()
+    if not pyproj.is_box_project:
+        raise ClickException("This is not a box project. Initialize with `box init`.")
+
+
+def check_pyproject() -> None:
+    """Raise a click exception if a pyproject.toml file is not found."""
+    if not Path("pyproject.toml").exists():
+        raise ClickException("No pyproject.toml file found.")
+
 
 @contextmanager
 def set_dir(dir: Path) -> None:

--- a/tests/cli/test_cli_clean.py
+++ b/tests/cli/test_cli_clean.py
@@ -120,8 +120,8 @@ def test_clean_no_pyproject(tmp_path_chdir, rye_project_no_box, init_folder):
     result = runner.invoke(cli, ["clean"])
 
     assert dist_dir.exists()
-    assert result.exit_code == 0
-    assert "Not a box project." in result.output
+    assert result.exit_code == 1
+    assert "This is not a box project." in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_cli_initialization.py
+++ b/tests/cli/test_cli_initialization.py
@@ -90,7 +90,7 @@ def test_pyproject_does_not_exist():
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["init", "-q"])
         assert result.exit_code != 0
-        assert result.output.__contains__("No `pyproject.toml` file found")
+        assert result.output.__contains__("No pyproject.toml file found")
 
 
 def test_pyproject_invalid_toml(tmp_path_chdir):

--- a/tests/func/test_utils.py
+++ b/tests/func/test_utils.py
@@ -2,7 +2,33 @@
 
 from pathlib import Path
 
+import pytest
+from rich_click import ClickException
+
 import box.utils as ut
+
+
+def test_check_boxproject(rye_project):
+    """Check if the box project is already initialized."""
+    ut.check_boxproject()
+
+
+def test_check_boxproject_error(rye_project_no_box):
+    """Raise a click exception if the box project is not found."""
+    with pytest.raises(ClickException):
+        ut.check_boxproject()
+
+
+def test_check_pyproject(rye_project):
+    """Check if pyproject.toml file is found."""
+    ut.check_pyproject()
+
+
+def test_check_pyproject_error(tmp_path):
+    """Raise a click exception if a pyproject.toml file is not found."""
+    with ut.set_dir(tmp_path):
+        with pytest.raises(ClickException):
+            ut.check_pyproject()
 
 
 def test_set_dir(tmp_path):


### PR DESCRIPTION
checks for pyproject file only if `init` is called, otherwise for box project and pyproject.
