### PR TITLE
Add queries in initialization as arguments

### DIFF
--- a/src/box/cli.py
+++ b/src/box/cli.py
@@ -24,10 +24,32 @@ def cli():
     is_flag=True,
     help="Quiet mode: don't ask questions and initialize with default values.",
 )
-def init(quiet):
+@click.option(
+    "-b",
+    "--builder",
+    type=click.Choice(PackageApp().builders),
+    help="Set the builder for the project.",
+)
+@click.option(
+    "-opt", "--optional-deps", help="Set optional dependencies for the project."
+)
+@click.option("-e", "--entry", help="Set the app entry for the project.")
+@click.option(
+    "-py",
+    "--python-version",
+    type=click.Choice(ut.PYAPP_PYTHON_VERSIONS),
+    help="Set the python version to use with PyApp.",
+)
+def init(quiet, builder, optional_deps, entry, python_version):
     """Initialize a new project in the current folder."""
     ut.check_pyproject()
-    my_init = InitializeProject(quiet=quiet)
+    my_init = InitializeProject(
+        quiet=quiet,
+        builder=builder,
+        optional_deps=optional_deps,
+        app_entry=entry,
+        python_version=python_version,
+    )
     my_init.initialize()
 
 
@@ -40,7 +62,13 @@ def init(quiet):
     help="Flag to enable verbose mode.",
 )
 def package(verbose):
-    """Build the project, then package it with PyApp."""
+    """Build the project, then package it with PyApp.
+
+    Note that if the pyapp source is already in the `build` directory,
+    it will not be downloaded and/or extracted again.
+    This speeds up the process if you are packaging multiple times.
+    If you want to re-download it, please clean the project first with `box clean`.
+    """
     ut.check_boxproject()
     my_packager = PackageApp(verbose=verbose)
     my_packager.check_requirements()

--- a/src/box/packager.py
+++ b/src/box/packager.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import tarfile
+from typing import List
 import urllib.request
 
 import rich_click as click
@@ -58,9 +59,9 @@ class PackageApp:
         self._config = None
 
     @property
-    def builders(self):
-        """Return a dictionary with supported builders and their commands."""
-        return self._builders
+    def builders(self) -> List:
+        """Return a list of supported builders and their commands."""
+        return list(self._builders.keys())
 
     @property
     def config(self) -> PyProjectParser:
@@ -76,7 +77,7 @@ class PackageApp:
         try:
             subprocess.run(self._builders[builder], **self.subp_kwargs)
         except KeyError as e:
-            raise KeyError("Unknown builder") from e
+            raise KeyError(f"Unknown {builder=}") from e
 
         fmt.success(f"Project built with {builder}.")
 

--- a/tests/cli/test_cli_initialization.py
+++ b/tests/cli/test_cli_initialization.py
@@ -50,6 +50,43 @@ def test_initialize_project_app_entry_typed(rye_project_no_box, app_entry):
     assert pyproj.python_version == py_version_exp
 
 
+def test_initialize_with_options(rye_project_no_box):
+    """Initialize a new project with options."""
+    py_version = "3.8"
+    entry_point = "myapp:entry"
+    optional_deps = "gui"
+    builder = "hatch"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "-e",
+            entry_point,
+            "-py",
+            py_version,
+            "-opt",
+            optional_deps,
+            "-b",
+            builder,
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Project initialized." in result.output
+
+    # assert it's now a box project
+    pyproj = PyProjectParser()
+    assert pyproj.is_box_project
+
+    # assert settings in pyproject are according to options selected
+    assert pyproj.builder == builder
+    assert pyproj.python_version == py_version
+    assert pyproj.optional_dependencies == optional_deps
+    assert pyproj.app_entry == entry_point
+
+
 def test_initialize_project_quiet(rye_project_no_box):
     """Initialize a new project quietly."""
     runner = CliRunner()
@@ -64,7 +101,7 @@ def test_initialize_project_quiet(rye_project_no_box):
     assert pyproj.python_version == ut.PYAPP_PYTHON_VERSIONS[-1]
 
 
-@pytest.mark.parametrize("builder", PackageApp().builders.keys())
+@pytest.mark.parametrize("builder", PackageApp().builders)
 def test_initialize_project_builders(rye_project_no_box, builder):
     """Initialize a new project with a specific builder."""
     runner = CliRunner()

--- a/tests/func/test_packager.py
+++ b/tests/func/test_packager.py
@@ -53,7 +53,7 @@ def test_builders(min_proj_no_box, mocker, builder):
     packager.build()
 
     sp_mock.assert_called_with(
-        packager.builders[builder], stdout=mocker.ANY, stderr=mocker.ANY
+        packager._builders[builder], stdout=mocker.ANY, stderr=mocker.ANY
     )
 
     expected_path = min_proj_no_box.joinpath("dist")


### PR DESCRIPTION
Now the user has the possibility to skip queries in the initialization by providing arguments. 
This is different from the `--quiet` mode, where default values are always assumed.
A combination of `--quiet` and specific arguments is also possible to default where one doesn't care.
