### PR TITLE
Add uninitialize command to CLI

### DIFF
--- a/src/box/cli.py
+++ b/src/box/cli.py
@@ -1,6 +1,7 @@
 import rich_click as click
 
 from box.cleaner import CleanProject
+from box.config import uninitialize
 from box.initialization import InitializeProject
 import box.formatters as fmt
 from box.packager import PackageApp
@@ -136,3 +137,23 @@ def clean(dist, build, target, source_pyapp, pyapp_folder):
         pyapp_folder=pyapp_folder,
     )
     my_cleaner.clean()
+
+
+@cli.command(name="uninit")
+@click.option(
+    "-c",
+    "--clean-project",
+    default=False,
+    is_flag=True,
+    help="Flag to clean the full project before uninitializing it.",
+)
+def uninit(clean_project):
+    """Uninitialize the project.
+
+    All references to `box` will be removed from the `pyproject.toml` file.
+    """
+    ut.check_pyproject()
+    if clean_project:
+        clean()
+    uninitialize()
+    fmt.success("Project un-initialized.")

--- a/src/box/config.py
+++ b/src/box/config.py
@@ -136,3 +136,16 @@ def pyproject_writer(key: str, value: Any) -> None:
 
     with open(pyproject_file, "w", newline="\n") as f:
         tomlkit.dump(doc, f)
+
+
+def uninitialize() -> None:
+    """Un-initialize a box project."""
+    pyproject_file = Path("pyproject.toml")
+
+    with open(pyproject_file, "rb") as f:
+        doc = tomlkit.load(f)
+
+    doc["tool"].remove("box")
+
+    with open(pyproject_file, "w", newline="\n") as f:
+        tomlkit.dump(doc, f)

--- a/tests/cli/test_cli_uninitialize.py
+++ b/tests/cli/test_cli_uninitialize.py
@@ -1,0 +1,37 @@
+"""Tests for un-initializing a project."""
+
+from click.testing import CliRunner
+
+from box.cli import cli
+from box.config import PyProjectParser
+
+
+def test_uninitialize(rye_project):
+    """Assure project is not a box project after un-initialization."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["uninit"])
+
+    assert result.exit_code == 0
+    assert "Project un-initialized." in result.output
+
+    # assert it's not a box project
+    pyproj = PyProjectParser()
+    assert not pyproj.is_box_project
+
+
+def test_uninitialize_clean(rye_project, mocker):
+    """Assure a full clean is called if option `-c` is given."""
+    clean_mock = mocker.patch("box.cli.clean")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["uninit", "-c"])
+
+    assert result.exit_code == 0
+    assert "Project un-initialized." in result.output
+
+    # assert it's not a box project
+    pyproj = PyProjectParser()
+    assert not pyproj.is_box_project
+
+    # assert clean was called
+    clean_mock.assert_called_once()


### PR DESCRIPTION
Allows to uninitialize the program.
A clean flag is provided to clean prior to unintializing.
