### PR TITLE
Unit test for CLI `cowsay`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev-dependencies = [
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.12.0",
     "gitpython>=3.1.42",
+    "build>=1.0.3",
 ]
 
 [tool.rye.scripts]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -8,6 +8,7 @@
 #   with-sources: false
 
 -e file:.
+build==1.0.3
 click==8.1.7
     # via box
     # via rich-click
@@ -25,11 +26,14 @@ markdown-it-py==3.0.0
 mdurl==0.1.2
     # via markdown-it-py
 packaging==23.2
+    # via build
     # via pytest
 pluggy==1.4.0
     # via pytest
 pygments==2.17.2
     # via rich
+pyproject-hooks==1.0.0
+    # via build
 pytest==8.0.0
     # via pytest-cov
     # via pytest-mock

--- a/tests/unit/test_cowsay.py
+++ b/tests/unit/test_cowsay.py
@@ -1,0 +1,38 @@
+# Build the `cowsay` project with PyApp.
+
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+from git import Repo
+import pytest
+
+from box.cli import cli
+
+
+GIT_URL = "https://github.com/VaasuDevanS/cowsay-python.git"  # repo for qtcowsay
+COMMIT_HASH = "9b627e154adb29f3840a0f92229b88fbd495baf4"  # commit hash for v6.1
+
+
+@pytest.mark.unit
+def test_gui_build():
+    """Build the `qtcowsay` project with PyApp."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # app expected
+        app_expected = Path("target/release/cowsay")
+        if os.name == "nt":  # on windows with have an .exe!
+            app_expected = app_expected.with_suffix(".exe")
+
+        # clone the repo
+        repo = Repo.clone_from(GIT_URL, ".")
+        repo.git.checkout(COMMIT_HASH)  # prevent repo-jacking
+
+        # init and build
+        runner.invoke(cli, ["init", "-q", "-b", "build"])
+        result = runner.invoke(cli, ["package"])
+
+        # check result
+        assert result.exit_code == 0
+        assert "Project successfully packaged" in result.output
+        assert app_expected.exists()

--- a/tests/unit/test_cowsay.py
+++ b/tests/unit/test_cowsay.py
@@ -11,7 +11,7 @@ from box.cli import cli
 
 
 GIT_URL = "https://github.com/VaasuDevanS/cowsay-python.git"  # repo for qtcowsay
-COMMIT_HASH = "9b627e154adb29f3840a0f92229b88fbd495baf4"  # commit hash for v6.1
+COMMIT_HASH = "3db622cefd8b11620ece7386d4151b5e734b078b"  # commit hash for v6.1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Add a unit test for [`cowsay`](https://github.com/VaasuDevanS/cowsay-python). Checking the repo out and fixing the commit hash to tag `v6.1`. This should prevent repo-jacking. 
Full packaging job with `box` using the `build` builder.
