### PR TITLE
Unit test workflow

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,4 +1,4 @@
-name: tests
+name: unittests
 
 on:
   push:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,50 @@
+name: tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  MAIN_PYTHON_VERSION: "3.12"
+
+jobs:
+  # Build and test
+  strategy:
+    matrix:
+      os: [ubuntu-latest, macos-latest, windows-latest]
+  unit-tests:
+    runs-on: {{matrix.os }}
+    steps:
+    - name: Checkout box
+      uses: actions/checkout@v4
+      with:
+        path: "box"
+    - name: Install python and setup project
+      uses: actions/setup-python@v5
+      with:
+          python-version: env.MAIN_PYTHON_VERSION
+    - name: Pip install
+      run: |
+        pip install box
+        pip install build
+    - name: Unit test with qtcowsay (GUI)
+      uses: actions/check-run-action@v4
+      with:
+        repository: trappitsch/qtcowsay
+        path: "qtcowsay"
+      run: |
+        cd qtcowsay
+        box init -q -b build
+        box package
+    - name: Unit test with cowsay (CLI)
+      uses: actions/check-run-action@v4
+      with:
+          repository: VassuDevanS/cowsay-python
+          path: "cowsay"
+      run: |
+          git checkout 3db622cefd8b11620ece7386d4151b5e734b078b
+          cd cowsay
+          box init -q -b build
+          box package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ dev-dependencies = [
 ]
 
 [tool.rye.scripts]
-test = "pytest"
-test_cov = "pytest --cov --cov-report xml"
+test = "pytest -m 'not unit'"
+test_cov = "pytest -m 'not unit' --cov --cov-report xml"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
Remove unit tests from actual full multi-python testing and add a separate unit test workflow that build a gui and a cli on linux, windows, and macos

