### PR TITLE
Cleanup tests

### DIFF
--- a/tests/cli/test_cli_clean.py
+++ b/tests/cli/test_cli_clean.py
@@ -49,7 +49,7 @@ def test_clean(rye_project):
         assert not folder.exists()
 
     assert result.exit_code == 0
-    assert result.output.__contains__("The whole project was cleaned.")
+    assert "The whole project was cleaned." in result.output
 
 
 @pytest.mark.parametrize(
@@ -91,7 +91,7 @@ def test_clean_folder(rye_project, option):
             assert folder.exists()
 
     assert result.exit_code == 0
-    assert result.output.__contains__(f"Folder(s) {folder_name} cleaned.")
+    assert f"Folder(s) {folder_name} cleaned." in result.output
 
 
 def test_clean_multiple_folders(rye_project):
@@ -106,7 +106,7 @@ def test_clean_multiple_folders(rye_project):
     assert build.exists()
 
     assert result.exit_code == 0
-    assert result.output.__contains__("Folder(s) dist, target cleaned.")
+    assert "Folder(s) dist, target cleaned." in result.output
 
 
 @pytest.mark.parametrize("init_folder", [True, False])

--- a/tests/cli/test_cli_initialization.py
+++ b/tests/cli/test_cli_initialization.py
@@ -178,7 +178,7 @@ def test_pyproject_does_not_exist():
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["init", "-q"])
         assert result.exit_code != 0
-        assert result.output.__contains__("No pyproject.toml file found")
+        assert "No pyproject.toml file found" in result.output
 
 
 def test_pyproject_invalid_toml(tmp_path_chdir):
@@ -187,4 +187,4 @@ def test_pyproject_invalid_toml(tmp_path_chdir):
     runner = CliRunner()
     result = runner.invoke(cli, ["init", "-q"])
     assert result.exit_code != 0
-    assert result.output.__contains__("Invalid `pyproject.toml` file")
+    assert "Invalid `pyproject.toml` file" in result.output

--- a/tests/func/test_packager.py
+++ b/tests/func/test_packager.py
@@ -132,7 +132,7 @@ def test_get_pyapp_no_file_found(rye_project, mocker):
     with pytest.raises(click.ClickException) as e:
         packager._get_pyapp()
 
-    assert e.value.args[0].__contains__("Error: no pyapp source code found")
+    assert "Error: no pyapp source code found" in e.value.args[0]
     url_mock.assert_called_with(PYAPP_SOURCE, Path("pyapp-source.tar.gz"))
 
 
@@ -166,14 +166,14 @@ def test_get_pyapp_wrong_no_pyapp_folder(rye_project, mocker):
     with pytest.raises(click.ClickException) as e:
         packager._get_pyapp()
 
-    assert e.value.args[0].__contains__("Error: no pyapp source code found")
+    assert "Error: no pyapp source code found" in e.value.args[0]
 
     rye_project.joinpath("build/pyapp-source.tar.gz").touch()
 
     with pytest.raises(click.ClickException) as e:
         packager._get_pyapp()
 
-    assert e.value.args[0].__contains__("Error: no pyapp source code folder found.")
+    assert "Error: no pyapp source code folder found." in e.value.args[0]
 
 
 def test_get_pyapp_local_wrong_file(rye_project):


### PR DESCRIPTION
remove `.__contains__()` statements in tests with `in`
