### PR TITLE
Propose already set values when initialized is triggered again

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -36,6 +36,10 @@ If you provided all the answers, your project should have been successfully init
     To still specify variables, just set them using the arguments discussed in the table above.
     And if you are happy with all the defaults, you should be good to do.
 
+!!! note
+    If you re-initalize a project, `box` will use the already set values as proposed default values.
+    If you re-initialize in quiet mode and just give one new option, all other options will stay the same.
+
 ## Packaging
 
 To package your project, simply run:

--- a/src/box/config.py
+++ b/src/box/config.py
@@ -1,5 +1,6 @@
 # Parse the pyproject.toml file
 
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, Union
 
@@ -70,7 +71,7 @@ class PyProjectParser:
             return {}
 
     @property
-    def possible_app_entries(self) -> Dict:
+    def possible_app_entries(self) -> OrderedDict:
         """Return [project.gui-scripts] or [project.scripts] entry if available.
 
         If no entry is available, return None. If more than one entry available,
@@ -78,7 +79,11 @@ class PyProjectParser:
 
         :return: A list of possible entry points or None.
         """
-        possible_entries = {}
+        possible_entries = OrderedDict()
+        try:
+            possible_entries["current-default"] = {"current": self.app_entry}
+        except KeyError:
+            pass
         try:
             possible_entries["gui-scripts"] = self._project["gui-scripts"]
         except KeyError:
@@ -87,6 +92,7 @@ class PyProjectParser:
             possible_entries["scripts"] = self._project["scripts"]
         except KeyError:
             pass
+        print(possible_entries)
         return possible_entries
 
     @property

--- a/tests/cli/test_cli_initialization.py
+++ b/tests/cli/test_cli_initialization.py
@@ -119,6 +119,46 @@ def test_initialize_with_options(rye_project_no_box):
     assert pyproj.optional_pyapp_variables == {"PYAPP_FULL_ISOLATION": "1"}
 
 
+def test_initialize_project_again(rye_project_no_box):
+    """Initialization of a previous project sets defaults from previous config."""
+    builder = "build"
+    entry_point = "myapp:entry"
+    entry_type = "module"
+    optional_deps = "gui"
+    py_version = "3.8"
+    pyapp_vars = "PYAPP_FULL_ISOLATION 1"
+
+    runner = CliRunner()
+    runner.invoke(
+        cli,
+        [
+            "init",
+            "-e",
+            entry_point,
+            "-et",
+            entry_type,
+            "-py",
+            py_version,
+            "-opt",
+            optional_deps,
+            "-b",
+            builder,
+            "--opt-pyapp-vars",
+            pyapp_vars,
+        ],
+    )
+
+    # now re-initialize with quiet and assure that the same options are set
+    runner.invoke(cli, ["init", "-q"])
+
+    pyproj = PyProjectParser()
+    assert pyproj.builder == builder
+    assert pyproj.python_version == py_version
+    assert pyproj.optional_dependencies == optional_deps
+    assert pyproj.app_entry == entry_point
+    assert pyproj.app_entry_type == entry_type
+
+
 def test_initialize_project_quiet(rye_project_no_box):
     """Initialize a new project quietly."""
     runner = CliRunner()

--- a/tests/func/test_initialization.py
+++ b/tests/func/test_initialization.py
@@ -7,16 +7,16 @@ from box.config import PyProjectParser
 from box.initialization import InitializeProject
 
 
-def test_app_entry(rye_project):
+def test_app_entry(rye_project_no_box):
     """Set the configuration in `pyproject.toml` to rye."""
     init = InitializeProject(quiet=True)
     init.initialize()
 
     pyproj = PyProjectParser()
-    assert pyproj.app_entry == f"{rye_project.name}:run"
+    assert pyproj.app_entry == f"{rye_project_no_box.name}:run"
 
 
-def test_set_builder(rye_project):
+def test_set_builder(rye_project_no_box):
     """Set the configuration in `pyproject.toml` to rye."""
     init = InitializeProject(quiet=True)
     init.initialize()


### PR DESCRIPTION
When user triggers initialization a second time (on an already existing box project), the defaults are now selected such that they represent the previous defaults. This allows for faster re-initalization, where the user only has to change the value that should be changed.
