### PR TITLE
add support for version selection

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -68,6 +68,17 @@ The following steps will be executed:
 
     This will put tye `.tar.gz` file of your project, which will then be packaged with `PyApp` into the `dist` folder.
 
+### Specify `PyApp` version
+
+If you would like to use a specific version of `PyApp` to package with,
+you can provide the version number with the `-pv`/`--pyapp-version` argument.
+Make sure that the version number corresponds to the correct tag on the
+[GitHub release page of PyApp](https://github.com/ofek/pyapp/releases).
+
+!!! note
+    If you have a newer version of `PyApp` already downloaded,
+    make sure to clean the project first with `box clean`.
+
 ### Local `PyApp` source
 
 If you would like to provide a local `PyApp` source,

--- a/src/box/cli.py
+++ b/src/box/cli.py
@@ -105,7 +105,13 @@ def init(
         "Provide path to the folder or the .tar.gz archive."
     ),
 )
-def package(verbose, pyapp_source):
+@click.option(
+    "-pv",
+    "--pyapp-version",
+    default="latest",
+    help="Specify the PyApp version to use. See release page on PyApp GitHub.",
+)
+def package(verbose, pyapp_source, pyapp_version):
     """Build the project, then package it with PyApp.
 
     Note that if the pyapp source is already in the `build` directory,
@@ -117,7 +123,7 @@ def package(verbose, pyapp_source):
     my_packager = PackageApp(verbose=verbose)
     my_packager.check_requirements()
     my_packager.build()
-    my_packager.package(local_source=pyapp_source)
+    my_packager.package(pyapp_version, local_source=pyapp_source)
     binary_file = my_packager.binary_name
     fmt.success(
         f"Project successfully packaged.\n"

--- a/tests/func/test_packager.py
+++ b/tests/func/test_packager.py
@@ -8,7 +8,7 @@ import urllib.request
 import rich_click as click
 import pytest
 
-from box.packager import PackageApp, PYAPP_SOURCE
+from box.packager import PackageApp, PYAPP_SOURCE_LATEST
 from box.config import PyProjectParser, pyproject_writer
 import box.utils as ut
 
@@ -133,7 +133,7 @@ def test_get_pyapp_no_file_found(rye_project, mocker):
         packager._get_pyapp()
 
     assert "Error: no pyapp source code found" in e.value.args[0]
-    url_mock.assert_called_with(PYAPP_SOURCE, Path("pyapp-source.tar.gz"))
+    url_mock.assert_called_with(PYAPP_SOURCE_LATEST, Path("pyapp-source.tar.gz"))
 
 
 def test_get_pyapp_source_exists(rye_project, mocker):


### PR DESCRIPTION
Add support for user selected PyApp version when packaging using the `-pv` or `--pyapp-version` argument. If not provided, defaults to latest version.
Update docs
