### PR TITLE
rename distribution for pypi to box-packager

### DIFF
--- a/docs/.includes/install.md
+++ b/docs/.includes/install.md
@@ -3,7 +3,7 @@
     To install with `pipx`, type:
 
     ```
-    pipx install box
+    pipx install box-packager
     ```
 
     Alternatively, you can install the latest version directly from the GitHub repo.
@@ -19,7 +19,7 @@
     To install box as a `rye` tool, type:
 
     ```
-    rye install box
+    rye install box-packager
     ```
 
     Alternatively, you can install the latest version directly from the GitHub repo.
@@ -37,7 +37,7 @@
     install it via:
 
     ```
-    pip install box
+    pip install box-packager
     ```
 
     Alternatively, you can install the latest version directly from the GitHub repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "box"
-version = "0.1.0.dev0"
+name = "box-packager"
+version = "0.1.0"
 description = "Automatic packaging and installers of your GUI with PyApp"
 readme = "README.md"
 authors = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -18,12 +18,12 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via box
+    # via box-packager
     # via mkdocs
     # via mkdocs-click
     # via rich-click
 colorama==0.4.6
-    # via box
+    # via box-packager
     # via mkdocs-material
 coverage==7.4.3
     # via pytest-cov
@@ -54,15 +54,15 @@ mdurl==0.1.2
 mergedeep==1.3.4
     # via mkdocs
 mkdocs==1.5.3
-    # via box
+    # via box-packager
     # via mkdocs-include-markdown-plugin
     # via mkdocs-material
 mkdocs-click==0.8.1
-    # via box
+    # via box-packager
 mkdocs-include-markdown-plugin==6.0.4
-    # via box
+    # via box-packager
 mkdocs-material==9.5.13
-    # via box
+    # via box-packager
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 packaging==23.2
@@ -102,17 +102,17 @@ regex==2023.12.25
 requests==2.31.0
     # via mkdocs-material
 rich==13.7.0
-    # via box
+    # via box-packager
     # via rich-click
 rich-click==1.7.3
-    # via box
+    # via box-packager
 ruff==0.2.2
 six==1.16.0
     # via python-dateutil
 smmap==5.0.1
     # via gitdb
 tomlkit==0.12.4
-    # via box
+    # via box-packager
 typing-extensions==4.10.0
     # via rich-click
 urllib3==2.2.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -17,12 +17,12 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via box
+    # via box-packager
     # via mkdocs
     # via mkdocs-click
     # via rich-click
 colorama==0.4.6
-    # via box
+    # via box-packager
     # via mkdocs-material
 ghp-import==2.1.0
     # via mkdocs
@@ -46,15 +46,15 @@ mdurl==0.1.2
 mergedeep==1.3.4
     # via mkdocs
 mkdocs==1.5.3
-    # via box
+    # via box-packager
     # via mkdocs-include-markdown-plugin
     # via mkdocs-material
 mkdocs-click==0.8.1
-    # via box
+    # via box-packager
 mkdocs-include-markdown-plugin==6.0.4
-    # via box
+    # via box-packager
 mkdocs-material==9.5.13
-    # via box
+    # via box-packager
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 packaging==23.2
@@ -83,14 +83,14 @@ regex==2023.12.25
 requests==2.31.0
     # via mkdocs-material
 rich==13.7.0
-    # via box
+    # via box-packager
     # via rich-click
 rich-click==1.7.3
-    # via box
+    # via box-packager
 six==1.16.0
     # via python-dateutil
 tomlkit==0.12.4
-    # via box
+    # via box-packager
 typing-extensions==4.10.0
     # via rich-click
 urllib3==2.2.1

--- a/src/box/cli.py
+++ b/src/box/cli.py
@@ -11,7 +11,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.version_option()
+@click.version_option(package_name="box_packager")
 def cli():
     """Automatic packaging and installers of your GUI with PyApp."""
     pass

--- a/tests/cli/test_box.py
+++ b/tests/cli/test_box.py
@@ -13,4 +13,6 @@ def test_version():
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert result.output.startswith("cli, version ")
-        assert result.output.rstrip().endswith(importlib.metadata.version("box"))
+        assert result.output.rstrip().endswith(
+            importlib.metadata.version("box_packager")
+        )


### PR DESCRIPTION
Rename packager itself to box-packager to avoid pypi naming conflicts

