### PR TITLE
Prep for v0.2.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,5 @@
+## v0.2.0
+
 - Released binary is now named after the project name, not after the python package name
 - Improvements to packaging: If PyApp fails and no binary exists, are more useful error message is provided.
 - Add command `box installer` to create an installer for the packaged program.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -98,10 +98,6 @@ where `LOCAL_SOURCE` is the path to the local source as described above.
 
 ## Installer
 
-!!! warning
-    Installer creation is currently in active development and is not yet available in the `pypi` release.
-    If you want to test what is available, please install from the GitHub main branch.
-
 Your packaged project is simply a file.
 However, you might want to distribute an installer to your users.
 Installers can be created simply in box by typing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "box-packager"
-version = "0.1.0"
+version = "0.2.0"
 description = "Automatic packaging and installers of your GUI with PyApp"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
- Changelog update
- Edit docs to remove warning for installers not in pypi release
- Bump version to `v0.2.0`
