### PR TITLE
Improve linux GUI installer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
+- Fix linux GUI uninstaller, such that it will only delete the installation folder if it is empty.
 - Allow icons to be stored in any folder that is named `assets`.
 - Finish installers for MacOS.
+    - CLI installer is created using [applecrate](https://github.com/RhetTbull/applecrate) and standard configuration.
+    - GUI installer is created by creating a minimal folder structure for an `.app` file, packing the executable and the icon into it, and then creating a `.dmg` file using [`dmgbuild`](https://github.com/dmgbuild/dmgbuild) (with standard configuration).
 
 ## v0.2.0
 

--- a/src/box/installer_utils/linux_hlp.py
+++ b/src/box/installer_utils/linux_hlp.py
@@ -182,7 +182,10 @@ echo "        echo \"Uninstaller aborted.\"" >> $UNINSTALL_FILE
 echo "        exit 1" >> $UNINSTALL_FILE
 echo "    fi" >> $UNINSTALL_FILE
 echo "" >> $UNINSTALL_FILE
-echo "rm -rf $INSTALL_DIR" >> $UNINSTALL_FILE
+echo "rm -f $INSTALL_DIR/$INSTALL_NAME" >> $UNINSTALL_FILE
+echo "rm -f $INSTALL_DIR/$ICON_NAME" >> $UNINSTALL_FILE
+echo "rm -f $UNINSTALL_FILE" >> $UNINSTALL_FILE
+echo "rmdir $INSTALL_DIR" >> $UNINSTALL_FILE
 echo "rm -f $DESKTOP_FILE" >> $UNINSTALL_FILE
 echo "rm -rf $HOME/.local/share/pyapp/$INSTALL_NAME" >> $UNINSTALL_FILE
 echo "" >> $UNINSTALL_FILE

--- a/tests/cli/test_cli_installer.py
+++ b/tests/cli/test_cli_installer.py
@@ -114,6 +114,9 @@ def test_installer_gui_linux(rye_project):
     assert file_content.find(icon_file_content, icon_start) != -1
     assert os.stat(installer_file).st_mode & stat.S_IXUSR != 0
 
+    # assure we only have one `rm -rf` in the install file (for pyapp folder)
+    assert file_content.count("rm -rf") == 1
+
     assert installer_file.name in result.output
 
 


### PR DESCRIPTION
Linux GUI uninstaller improvements.

- Deletes the executable
- Deletes the stored icon
- Deletes the uninstaller itself
- Then tries to delete the folder with `rmdir`, which will only succeed if it's empty at this point!

Only `rm -rf` used is for pyapp (which is tested for as well now).
